### PR TITLE
fix small error in usage description

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ jsesc(/©𝌆/g);
 
 // Escaping an array
 jsesc([
-  'Ich ♥ Bücher': 'foo 𝌆 bar'
+  'Ich ♥ Bücher', 'foo 𝌆 bar'
 ]);
 // → '[\'Ich \\u2665 B\\xFCcher\',\'foo \\uD834\\uDF06 bar\']'
 


### PR DESCRIPTION
There was a small typo: Array items were separated by `:` instead of `,` in README.md.
