### PR TITLE
Allow changing wrap and quotes options when using json option

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ This setting has no effect on the output for strings or regular expressions.
 
 #### `json`
 
-The `json` option takes a boolean value (`true` or `false`), and defaults to `false` (disabled). When enabled, the output is always valid JSON. [Hexadecimal character escape sequences](http://mathiasbynens.be/notes/javascript-escapes#hexadecimal) and [the `\v` or `\0` escape sequences](http://mathiasbynens.be/notes/javascript-escapes#single) will not be used. Setting `json: true` implies `quotes: 'double', wrap: true`.
+The `json` option takes a boolean value (`true` or `false`), and defaults to `false` (disabled). When enabled, the output is always valid JSON. [Hexadecimal character escape sequences](http://mathiasbynens.be/notes/javascript-escapes#hexadecimal) and [the `\v` or `\0` escape sequences](http://mathiasbynens.be/notes/javascript-escapes#single) will not be used. Setting `json: true` implies `quotes: 'double', wrap: true`. However, these values may be overridden in needed.
 
 ```js
 jsesc('foo\x00bar\xFF\uFFFDbaz', {

--- a/jsesc.js
+++ b/jsesc.js
@@ -93,15 +93,16 @@
 			'indent': '\t',
 			'__indent': '',
 		};
+		if (options && options.json) {
+			defaults.quotes = 'double';
+			defaults.wrap = true;
+		}
 		options = extend(defaults, options);
 		if (options.quotes != 'single' && options.quotes != 'double') {
 			options.quotes = 'single';
 		}
 		var json = options.json;
-		if (json) {
-			options.quotes = 'double';
-			options.wrap = true;
-		}
+		
 		var quote = options.quotes == 'double' ? '"' : '\'';
 		var compact = options.compact;
 		var indent = options.indent;

--- a/src/jsesc.js
+++ b/src/jsesc.js
@@ -93,15 +93,16 @@
 			'indent': '\t',
 			'__indent': '',
 		};
+		if (options && options.json) {
+			defaults.quotes = 'double';
+			defaults.wrap = true;
+		}
 		options = extend(defaults, options);
 		if (options.quotes != 'single' && options.quotes != 'double') {
 			options.quotes = 'single';
 		}
 		var json = options.json;
-		if (json) {
-			options.quotes = 'double';
-			options.wrap = true;
-		}
+		
 		var quote = options.quotes == 'double' ? '"' : '\'';
 		var compact = options.compact;
 		var indent = options.indent;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -182,8 +182,7 @@
 		equal(
 			jsesc('foo\x00bar\uFFFDbaz', {
 				'escapeEverything': true,
-				'json': true,
-				'quotes': 'single' // `json: true` should override this setting
+				'json': true
 			}),
 			'"\\u0066\\u006F\\u006F\\u0000\\u0062\\u0061\\u0072\\uFFFD\\u0062\\u0061\\u007A"',
 			'JSON-stringifying a string with `escapeEverything: true`'
@@ -191,8 +190,7 @@
 		equal(
 			jsesc({ 'foo\x00bar\uFFFDbaz': 'foo\x00bar\uFFFDbaz' }, {
 				'escapeEverything': true,
-				'json': true,
-				'quotes': 'single' // `json: true` should override this setting
+				'json': true
 			}),
 			'{"\\u0066\\u006F\\u006F\\u0000\\u0062\\u0061\\u0072\\uFFFD\\u0062\\u0061\\u007A":"\\u0066\\u006F\\u006F\\u0000\\u0062\\u0061\\u0072\\uFFFD\\u0062\\u0061\\u007A"}',
 			'JSON-stringifying a flat object with `escapeEverything: true`'
@@ -200,11 +198,35 @@
 		equal(
 			jsesc(['foo\x00bar\uFFFDbaz', 'foo\x00bar\uFFFDbaz'], {
 				'escapeEverything': true,
-				'json': true,
-				'quotes': 'single' // `json: true` should override this setting
+				'json': true
 			}),
 			'["\\u0066\\u006F\\u006F\\u0000\\u0062\\u0061\\u0072\\uFFFD\\u0062\\u0061\\u007A","\\u0066\\u006F\\u006F\\u0000\\u0062\\u0061\\u0072\\uFFFD\\u0062\\u0061\\u007A"]',
 			'JSON-stringifying a flat array with `escapeEverything: true`'
+		);
+		equal(
+			jsesc("foo\x00bar", {
+				'json':true,
+				'wrap':false	// can override json default wrap
+			}),
+			'foo\\u0000bar',
+			'escaping json without wrapping in quotes'
+		);
+		equal(
+			jsesc('foo "\x00" bar', {
+				'json':true,
+				'wrap':false	// can override json default wrap
+			}),
+			'foo \\"\\u0000\\" bar',
+			'escaping json without wrapping in quotes - with default double quote escape'
+		);
+		equal(
+			jsesc('foo "\x00" bar', {
+				'json':true,
+				'quotes':'single',	// can override json default quote and wrap
+				'wrap':false
+			}),
+			'foo "\\u0000" bar',
+			'escaping json, but override to escape single quotes'
 		);
 		equal(
 			jsesc(/foo©bar𝌆[a-z0-9]ö/ig),


### PR DESCRIPTION
json option implies wrap and double quotes in addition to changing some escaping behavior. This change allows the quote and wrap options to be changed while still allowing json option to be used. This is especially useful when you need to escape a string that is embedded in a JSON field.
