### PR TITLE
Add an option to allow lowercase hexadecimal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,18 @@ jsesc([ undefined, -Infinity ], {
 
 **Note:** Using this option on objects or arrays that contain non-string values relies on `JSON.stringify()`. For legacy environments like IE ≤ 7, use [a `JSON` polyfill](http://bestiejs.github.io/json3/).
 
+#### `lowercaseHex`
+
+The `lowercaseHex` option takes a boolean value (`true` or `false`), and defaults to `false`. When enabled, the hexadecimal values in the output are in lower case.
+
+```js
+jsesc('Ich ♥ Bücher', {
+  'lowercaseHex': true,
+});
+// → 'Ich \\u2665 B\\xfccher'
+
+```
+
 ### `jsesc.version`
 
 A string representing the semantic version number.

--- a/bin/jsesc
+++ b/bin/jsesc
@@ -30,6 +30,7 @@
 				'\tjsesc [-j | --json] [string]',
 				'\tjsesc [-o | --object] [stringified_object]', // `JSON.parse()` the argument
 				'\tjsesc [-p | --pretty] [string]', // `compact: false`
+				'\tjsesc [-l | --lowercase-hex] [string]',
 				'\tjsesc [-v | --version]',
 				'\tjsesc [-h | --help]',
 				'\nExamples:\n',
@@ -80,6 +81,10 @@
 			if (/^(?:-p|--pretty)$/.test(string)) {
 				isObject = true;
 				options.compact = false;
+				return;
+			}
+			if (/^(?:-l|--lowercase-hex)$/.test(string)) {
+				options.lowercaseHex = true;
 				return;
 			}
 

--- a/jsesc.js
+++ b/jsesc.js
@@ -8,7 +8,7 @@
 	var freeModule = typeof module == 'object' && module &&
 		module.exports == freeExports && module;
 
-	// Detect free variable `global`, from Node.js/io.js or Browserified code,
+	// Detect free variable `global`, from Node.js or Browserified code,
 	// and use it as `root`
 	var freeGlobal = typeof global == 'object' && global;
 	if (freeGlobal.global === freeGlobal || freeGlobal.window === freeGlobal) {
@@ -95,6 +95,7 @@
 			'es6': false,
 			'json': false,
 			'compact': true,
+			'lowercaseHex': false,
 			'indent': '\t',
 			'__indent__': ''
 		};
@@ -189,7 +190,11 @@
 					if (second >= 0xDC00 && second <= 0xDFFF) { // low surrogate
 						// https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
 						codePoint = (first - 0xD800) * 0x400 + second - 0xDC00 + 0x10000;
-						result += '\\u{' + codePoint.toString(16).toUpperCase() + '}';
+						var hexadecimal = codePoint.toString(16);
+						if (!options.lowercaseHex) {
+							hexadecimal = hexadecimal.toUpperCase();
+						}
+						result += '\\u{' + hexadecimal + '}';
 						index++;
 						continue;
 					}
@@ -225,7 +230,10 @@
 				continue;
 			}
 			var charCode = character.charCodeAt(0);
-			var hexadecimal = charCode.toString(16).toUpperCase();
+			var hexadecimal = charCode.toString(16);
+			if (!options.lowercaseHex) {
+				hexadecimal = hexadecimal.toUpperCase();
+			}
 			var longhand = hexadecimal.length > 2 || json;
 			var escaped = '\\' + (longhand ? 'u' : 'x') +
 				('0000' + hexadecimal).slice(longhand ? -4 : -2);
@@ -253,7 +261,7 @@
 			return jsesc;
 		});
 	}	else if (freeExports && !freeExports.nodeType) {
-		if (freeModule) { // in Node.js, io.js, or RingoJS v0.8.0+
+		if (freeModule) { // in Node.js or RingoJS v0.8.0+
 			freeModule.exports = jsesc;
 		} else { // in Narwhal or RingoJS v0.7.0-
 			freeExports.jsesc = jsesc;

--- a/man/jsesc.1
+++ b/man/jsesc.1
@@ -21,6 +21,8 @@
 .br
 .Op Fl p | -pretty Ar string
 .br
+.Op Fl u | -uppercase-hex Ar string
+.br
 .Op Fl v | -version
 .br
 .Op Fl h | -help
@@ -53,6 +55,8 @@ settings.
 Treat the input as a JavaScript object rather than a string. Accepted values are flat arrays containing only string values, and flat objects containing only string values.
 .It Sy "-p, --pretty"
 Pretty-print the output for objects, using whitespace to make it more readable. Setting this flag enables the
+.It Sy "-u, --lowercase-hex"
+Convert the hexadecimal values to lowercase.
 .Ar -o | --object
 setting.
 .It Sy "-v, --version"

--- a/src/jsesc.js
+++ b/src/jsesc.js
@@ -95,6 +95,7 @@
 			'es6': false,
 			'json': false,
 			'compact': true,
+			'lowercaseHex': false,
 			'indent': '\t',
 			'__indent__': ''
 		};
@@ -189,7 +190,11 @@
 					if (second >= 0xDC00 && second <= 0xDFFF) { // low surrogate
 						// https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
 						codePoint = (first - 0xD800) * 0x400 + second - 0xDC00 + 0x10000;
-						result += '\\u{' + codePoint.toString(16).toUpperCase() + '}';
+						var hexadecimal = codePoint.toString(16);
+						if (!options.lowercaseHex) {
+							hexadecimal = hexadecimal.toUpperCase();
+						}
+						result += '\\u{' + hexadecimal + '}';
 						index++;
 						continue;
 					}
@@ -225,7 +230,10 @@
 				continue;
 			}
 			var charCode = character.charCodeAt(0);
-			var hexadecimal = charCode.toString(16).toUpperCase();
+			var hexadecimal = charCode.toString(16);
+			if (!options.lowercaseHex) {
+				hexadecimal = hexadecimal.toUpperCase();
+			}
 			var longhand = hexadecimal.length > 2 || json;
 			var escaped = '\\' + (longhand ? 'u' : 'x') +
 				('0000' + hexadecimal).slice(longhand ? -4 : -2);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -287,6 +287,100 @@
 			'{"hello":"world","\\uD83D\\uDCA9":"foo","pile":"\\uD83D\\uDCA9"}',
 			'`toJSON` methods are not called when `json: false`'
 		);
+		equal(
+			jsesc('\u2192\xE9', {
+				'lowercaseHex': true
+			}),
+			'\\u2192\\xe9',
+			'Alphabetical hexadecimal digits are lowercase when `lowercaseHex: true`'
+		);
+		equal(
+			jsesc('\u2192\xe9', {
+				'lowercaseHex': true,
+				'json': true
+			}),
+			'"\\u2192\\u00e9"',
+			'Alphabetical hexadecimal digits are lowercase when `lowercaseHex: alse` and `json: true`'
+		);
+		equal(
+			jsesc('ççaçç', {
+				'lowercaseHex': true,
+				'escapeEverything': true
+			}),
+			'\\xe7\\xe7\\x61\\xe7\\xe7',
+			'Alphabetical hexadecimal digits are lowercase when `lowercaseHex: true` and `escapeEverything: true`'
+		);
+		equal(
+			jsesc('\u2192\xE9', {
+				'lowercaseHex': true,
+				'es6': true
+			}),
+			'\\u2192\\xe9',
+			'Alphabetical hexadecimal digits are lowercase when `lowercaseHex: true` and `es6: true`'
+		);
+		equal(
+			jsesc('\u2192\xE9', {
+				'lowercaseHex': true,
+				'compact': true
+			}),
+			'\\u2192\\xe9',
+			'Alphabetical hexadecimal digits are lowercase when `lowercaseHex: true` and `compact: true`'
+		);
+		equal(
+			jsesc('\u2192\xE9', {
+				'lowercaseHex': true,
+				'indent': true
+			}),
+			'\\u2192\\xe9',
+			'Alphabetical hexadecimal digits are lowercase when `lowercaseHex: true` and `indent: true`'
+		);
+		equal(
+			jsesc('\u2192\xE9', {
+				'lowercaseHex': false
+			}),
+			'\\u2192\\xE9',
+			'Alphabetical hexadecimal digits are uppercase when `lowercaseHex: false`'
+		);
+		equal(
+			jsesc('\u2192\xe9', {
+				'lowercaseHex': false,
+				'json': true
+			}),
+			'"\\u2192\\u00E9"',
+			'Alphabetical hexadecimal digits are uppercase when `lowercaseHex: alse` and `json: true`'
+		);
+		equal(
+			jsesc('ççaçç', {
+				'lowercaseHex': false,
+				'escapeEverything': true
+			}),
+			'\\xE7\\xE7\\x61\\xE7\\xE7',
+			'Alphabetical hexadecimal digits are uppercase when `lowercaseHex: false` and `escapeEverything: true`'
+		);
+		equal(
+			jsesc('\u2192\xE9', {
+				'lowercaseHex': false,
+				'es6': true
+			}),
+			'\\u2192\\xE9',
+			'Alphabetical hexadecimal digits are uppercase when `lowercaseHex: true` and `es6: true`'
+		);
+		equal(
+			jsesc('\u2192\xE9', {
+				'lowercaseHex': false,
+				'compact': true
+			}),
+			'\\u2192\\xE9',
+			'Alphabetical hexadecimal digits are uppercase when `lowercaseHex: false` and `compact: true`'
+		);
+		equal(
+			jsesc('\u2192\xE9', {
+				'lowercaseHex': false,
+				'indent': true
+			}),
+			'\\u2192\\xE9',
+			'Alphabetical hexadecimal digits are uppercase when `lowercaseHex: false` and `indent: true`'
+		);
 	});
 
 	if (runExtendedTests) {


### PR DESCRIPTION
Here is a way to lowercase the generated codepoints (useful for python compatibility for instance).