### PR TITLE
add forceLonghand option

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,24 @@ jsesc(42, {
 //      ^^
 ```
 
+#### `forceLonghand`
+
+The `forceLonghand` option takes a boolean value (`true` or `false`), and defaults to `false` (disabled). It will make sure replaced characters will use the longer unicode format (`\u00YY`) instead of shortened one (`\xYY`).
+
+```js
+jsesc({ 'Ich ♥ Bücher': 'foo 𝌆 bar' }, {
+  'forceLonghand': false // this is the default
+});
+// → '{\n\t\'Ich \u2665 B\xFCcher\': \'foo \uD834\uDF06 bar\'\n}'
+//                        ^^^
+
+jsesc({ 'Ich ♥ Bücher': 'foo 𝌆 bar' }, {
+  'forceLonghand': true 
+});
+// → '{\n\t\'Ich \u2665 B\uOOFCcher\': \'foo \uD834\uDF06 bar\'\n}'
+//                        ^^^^^
+```
+
 ### `jsesc.version`
 
 A string representing the semantic version number.

--- a/bin/jsesc
+++ b/bin/jsesc
@@ -29,6 +29,7 @@
 				'\tjsesc [-t | --escape-etago] [string]',
 				'\tjsesc [-6 | --es6] [string]',
 				'\tjsesc [-l | --lowercase-hex] [string]',
+				'\tjsesc [-f | --force-longhand] [string]',
 				'\tjsesc [-j | --json] [string]',
 				'\tjsesc [-o | --object] [stringified_object]', // `JSON.parse()` the argument
 				'\tjsesc [-p | --pretty] [string]', // `compact: false`
@@ -77,6 +78,10 @@
 			}
 			if (/^(?:-l|--lowercase-hex)$/.test(string)) {
 				options.lowercaseHex = true;
+				return;
+			}
+			if (/^(?:-f|--force-longhand)$/.test(string)) {
+				options.forceLonghand = true;
 				return;
 			}
 			if (/^(?:-j|--json)$/.test(string)) {

--- a/jsesc.js
+++ b/jsesc.js
@@ -90,6 +90,7 @@ const jsesc = (argument, options) => {
 		'json': false,
 		'compact': true,
 		'lowercaseHex': false,
+		'forceLonghand': false,
 		'numbers': 'decimal',
 		'indent': '\t',
 		'indentLevel': 0,
@@ -303,7 +304,7 @@ const jsesc = (argument, options) => {
 		if (!lowercaseHex) {
 			hexadecimal = hexadecimal.toUpperCase();
 		}
-		const longhand = hexadecimal.length > 2 || json;
+		const longhand = options.forceLonghand ? true : hexadecimal.length > 2 || json;
 		const escaped = '\\' + (longhand ? 'u' : 'x') +
 			('0000' + hexadecimal).slice(longhand ? -4 : -2);
 		result += escaped;

--- a/src/jsesc.js
+++ b/src/jsesc.js
@@ -90,6 +90,7 @@ const jsesc = (argument, options) => {
 		'json': false,
 		'compact': true,
 		'lowercaseHex': false,
+		'forceLonghand': false,
 		'numbers': 'decimal',
 		'indent': '\t',
 		'indentLevel': 0,
@@ -303,7 +304,7 @@ const jsesc = (argument, options) => {
 		if (!lowercaseHex) {
 			hexadecimal = hexadecimal.toUpperCase();
 		}
-		const longhand = hexadecimal.length > 2 || json;
+		const longhand = options.forceLonghand ? true : hexadecimal.length > 2 || json;
 		const escaped = '\\' + (longhand ? 'u' : 'x') +
 			('0000' + hexadecimal).slice(longhand ? -4 : -2);
 		result += escaped;


### PR DESCRIPTION
Closes #42 

We can now use `--force-longhand` in CLI  or `{ longHand: true }` in options to prevent shortening of `00` unicode character code.

Maybe we could push a tag to include that feature.