### PR TITLE
When quote = backtick, backtick characters are not escaped

### DIFF
--- a/jsesc.js
+++ b/jsesc.js
@@ -71,7 +71,7 @@ const singleEscapes = {
 const regexSingleEscape = /["'\\\b\f\n\r\t]/;
 
 const regexDigit = /[0-9]/;
-const regexWhitelist = /[ !#-&\(-\[\]-~]/;
+const regexWhitelist = /[ !#-&\(-\[\]-_a-~]/;
 
 const jsesc = (argument, options) => {
 	const increaseIndentation = () => {

--- a/src/data.js
+++ b/src/data.js
@@ -7,7 +7,8 @@ const set = regenerate()
 	.addRange(0x20, 0x7E) // printable ASCII symbols
 	.remove('"')          // not `"`
 	.remove('\'')         // not `'`
-	.remove('\\');        // not `\`
+	.remove('\\')         // not `\`
+	.remove('`');         // not '`'
 
 module.exports = {
 	'whitelist': set.toString(),

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -38,18 +38,18 @@ describe('common usage', function() {
 			'Invalid `quotes` setting'
 		);
 		assert.equal(
-			jsesc('foo${1+1}', {
+			jsesc('foo${1+1} `bar`', {
 				'quotes': 'backtick'
 			}),
-			'foo\\${1+1}',
+			'foo\\${1+1} \\`bar\\`',
 			'`quotes: \'backtick\'`'
 		);
 		assert.equal(
-			jsesc('foo${1+1}', {
+			jsesc('foo${1+1} `bar`', {
 				'quotes': 'backtick',
 				'wrap': true
 			}),
-			'`foo\\${1+1}`',
+			'`foo\\${1+1} \\`bar\\``',
 			'`quotes: \'backtick\'` + `wrap: true`'
 		);
 		assert.equal(


### PR DESCRIPTION
In this code, backtick characters are not escaped:

```
jsesc('`Lorem` ipsum "dolor" sit \'amet\' etc.', {
          'quotes': 'backtick'
});
```

Expected result: 
```
'\\`Lorem\\` ipsum "dolor" sit \'amet\' etc.'
```

Actual result: 
```
'`Lorem` ipsum "dolor" sit \'amet\' etc.'
```

The cause of the problem is in `regexWhitelist`. The backtick character is in the whitelist, so the `if` statement at line 265 fires, and the code never gets to the special-case handling for the backtick. I updated the whitelist so that it doesn't include the backtick.

