### PR TITLE
Replace string escaping with regex replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ The `minimal` option takes a boolean value (`true` or `false`), and defaults to 
 * U+2028 `\u2028`
 * U+2029 `\u2029`
 * whatever symbol is being used for wrapping string literals (based on [the `quotes` option](#quotes))
+* [lone surrogates](https://esdiscuss.org/topic/code-points-vs-unicode-scalar-values#content-14)
 
 Note: with this option enabled, jsesc output is no longer guaranteed to be ASCII-safe.
 

--- a/jsesc.js
+++ b/jsesc.js
@@ -28,6 +28,16 @@ const forEach = (array, callback) => {
 	}
 };
 
+const fourHexEscape = (hex) => {
+	return '\\u' + ('0000' + hex).slice(-4);
+}
+
+const hexadecimal = (code, lowercase) => {
+	let hexadecimal = code.toString(16);
+	if (lowercase) return hexadecimal;
+	return hexadecimal.toUpperCase();
+}
+
 const toString = object.toString;
 const isArray = Array.isArray;
 const isBuffer = Buffer.isBuffer;
@@ -57,8 +67,6 @@ const isSet = (value) => {
 
 // https://mathiasbynens.be/notes/javascript-escapes#single
 const singleEscapes = {
-	'"': '\\"',
-	'\'': '\\\'',
 	'\\': '\\\\',
 	'\b': '\\b',
 	'\f': '\\f',
@@ -68,10 +76,12 @@ const singleEscapes = {
 	// `\v` is omitted intentionally, because in IE < 9, '\v' == 'v'.
 	// '\v': '\\x0B'
 };
-const regexSingleEscape = /["'\\\b\f\n\r\t]/;
+const regexSingleEscape = /[\\\b\f\n\r\t]/;
 
 const regexDigit = /[0-9]/;
-const regexWhitelist = /[ !#-&\(-\[\]-_a-~]/;
+
+const escapeEverythingRegex = /([\uD800-\uDBFF][\uDC00-\uDFFF])|([\uD800-\uDFFF])|(['"`])|[^]/g;
+const escapeNonAsciiRegex = /([\uD800-\uDBFF][\uDC00-\uDFFF])|([\uD800-\uDFFF])|(['"`])|[^ !#-&\(-\[\]-_a-~]/g;
 
 const jsesc = (argument, options) => {
 	const increaseIndentation = () => {
@@ -234,92 +244,68 @@ const jsesc = (argument, options) => {
 		}
 	}
 
-	const string = argument;
-	// Loop over each code unit in the string and escape it
-	let index = -1;
-	const length = string.length;
-	result = '';
-	while (++index < length) {
-		const character = string.charAt(index);
-		if (options.es6) {
-			const first = string.charCodeAt(index);
-			if ( // check if it’s the start of a surrogate pair
-				first >= 0xD800 && first <= 0xDBFF && // high surrogate
-				length > index + 1 // there is a next code unit
-			) {
-				const second = string.charCodeAt(index + 1);
-				if (second >= 0xDC00 && second <= 0xDFFF) { // low surrogate
-					// https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
-					const codePoint = (first - 0xD800) * 0x400 + second - 0xDC00 + 0x10000;
-					let hexadecimal = codePoint.toString(16);
-					if (!lowercaseHex) {
-						hexadecimal = hexadecimal.toUpperCase();
-					}
-					result += '\\u{' + hexadecimal + '}';
-					++index;
-					continue;
-				}
+	const regex = options.escapeEverything ? escapeEverythingRegex : escapeNonAsciiRegex;
+	result = argument.replace(regex, (char, pair, lone, quoteChar, index, string) => {
+		if (pair) {
+			if (options.minimal) return pair;
+			const first = pair.charCodeAt(0);
+			const second = pair.charCodeAt(1);
+			if (options.es6) {
+				// https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+				const codePoint = (first - 0xD800) * 0x400 + second - 0xDC00 + 0x10000;
+				const hex = hexadecimal(codePoint, lowercaseHex);
+				return '\\u{' + hex + '}';
 			}
+			return fourHexEscape(hexadecimal(first, lowercaseHex)) + fourHexEscape(hexadecimal(second, lowercaseHex));
 		}
-		if (!options.escapeEverything) {
-			if (regexWhitelist.test(character)) {
-				// It’s a printable ASCII character that is not `"`, `'` or `\`,
-				// so don’t escape it.
-				result += character;
-				continue;
-			}
-			if (character == '"') {
-				result += quote == character ? '\\"' : character;
-				continue;
-			}
-			if (character == '`') {
-				result += quote == character ? '\\`' : character;
-				continue;
-			}
-			if (character == '\'') {
-				result += quote == character ? '\\\'' : character;
-				continue;
-			}
+
+		if (lone) {
+			return fourHexEscape(hexadecimal(lone.charCodeAt(0), lowercaseHex));
 		}
+
 		if (
-			character == '\0' &&
+			char == '\0' &&
 			!json &&
 			!regexDigit.test(string.charAt(index + 1))
 		) {
-			result += '\\0';
-			continue;
+			return '\\0';
 		}
-		if (regexSingleEscape.test(character)) {
+
+		if (quoteChar) {
+			if (quoteChar == quote || options.escapeEverything) {
+				return '\\' + quoteChar;
+			}
+			return quoteChar;
+		}
+
+		if (regexSingleEscape.test(char)) {
 			// no need for a `hasOwnProperty` check here
-			result += singleEscapes[character];
-			continue;
+			return singleEscapes[char];
 		}
-		const charCode = character.charCodeAt(0);
-		if (options.minimal && charCode != 0x2028 && charCode != 0x2029) {
-			result += character;
-			continue;
+
+		if (options.minimal && char != '\u2028' && char != '\u2029') {
+			return char;
 		}
-		let hexadecimal = charCode.toString(16);
-		if (!lowercaseHex) {
-			hexadecimal = hexadecimal.toUpperCase();
+
+		const hex = hexadecimal(char.charCodeAt(0), lowercaseHex);
+		if (json || hex.length > 2) {
+			return fourHexEscape(hex);
 		}
-		const longhand = hexadecimal.length > 2 || json;
-		const escaped = '\\' + (longhand ? 'u' : 'x') +
-			('0000' + hexadecimal).slice(longhand ? -4 : -2);
-		result += escaped;
-		continue;
-	}
-	if (options.wrap) {
-		result = quote + result + quote;
-	}
+
+		return '\\x' + ('00' + hex).slice(-2);
+	});
+
 	if (quote == '`') {
-		result = result.replace(/\$\{/g, '\\\$\{');
+		result = result.replace(/\$\{/g, '\\${');
 	}
 	if (options.isScriptContext) {
 		// https://mathiasbynens.be/notes/etago
-		return result
+		result = result
 			.replace(/<\/(script|style)/gi, '<\\/$1')
 			.replace(/<!--/g, json ? '\\u003C!--' : '\\x3C!--');
+	}
+	if (options.wrap) {
+		result = quote + result + quote;
 	}
 	return result;
 };

--- a/jsesc.js
+++ b/jsesc.js
@@ -36,7 +36,7 @@ const hexadecimal = (code, lowercase) => {
 	let hexadecimal = code.toString(16);
 	if (lowercase) return hexadecimal;
 	return hexadecimal.toUpperCase();
-}
+};
 
 const toString = object.toString;
 const isArray = Array.isArray;

--- a/src/data.js
+++ b/src/data.js
@@ -11,6 +11,6 @@ const set = regenerate()
 	.remove('`');         // not '`'
 
 module.exports = {
-	'whitelist': set.toString(),
+	'whitelist': set.toString().slice(1, -1),
 	'version': require('../package.json').version
 };

--- a/src/jsesc.js
+++ b/src/jsesc.js
@@ -28,6 +28,16 @@ const forEach = (array, callback) => {
 	}
 };
 
+const fourHexEscape = (hex) => {
+	return '\\u' + ('0000' + hex).slice(-4);
+}
+
+const hexadecimal = (code, lowercase) => {
+	let hexadecimal = code.toString(16);
+	if (lowercase) return hexadecimal;
+	return hexadecimal.toUpperCase();
+}
+
 const toString = object.toString;
 const isArray = Array.isArray;
 const isBuffer = Buffer.isBuffer;
@@ -57,8 +67,6 @@ const isSet = (value) => {
 
 // https://mathiasbynens.be/notes/javascript-escapes#single
 const singleEscapes = {
-	'"': '\\"',
-	'\'': '\\\'',
 	'\\': '\\\\',
 	'\b': '\\b',
 	'\f': '\\f',
@@ -68,10 +76,12 @@ const singleEscapes = {
 	// `\v` is omitted intentionally, because in IE < 9, '\v' == 'v'.
 	// '\v': '\\x0B'
 };
-const regexSingleEscape = /["'\\\b\f\n\r\t]/;
+const regexSingleEscape = /[\\\b\f\n\r\t]/;
 
 const regexDigit = /[0-9]/;
-const regexWhitelist = /<%= whitelist %>/;
+
+const escapeEverythingRegex = /([\uD800-\uDBFF][\uDC00-\uDFFF])|([\uD800-\uDFFF])|(['"`])|[^]/g;
+const escapeNonAsciiRegex = /([\uD800-\uDBFF][\uDC00-\uDFFF])|([\uD800-\uDFFF])|(['"`])|[^<%= whitelist %>]/g;
 
 const jsesc = (argument, options) => {
 	const increaseIndentation = () => {
@@ -234,92 +244,68 @@ const jsesc = (argument, options) => {
 		}
 	}
 
-	const string = argument;
-	// Loop over each code unit in the string and escape it
-	let index = -1;
-	const length = string.length;
-	result = '';
-	while (++index < length) {
-		const character = string.charAt(index);
-		if (options.es6) {
-			const first = string.charCodeAt(index);
-			if ( // check if it’s the start of a surrogate pair
-				first >= 0xD800 && first <= 0xDBFF && // high surrogate
-				length > index + 1 // there is a next code unit
-			) {
-				const second = string.charCodeAt(index + 1);
-				if (second >= 0xDC00 && second <= 0xDFFF) { // low surrogate
-					// https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
-					const codePoint = (first - 0xD800) * 0x400 + second - 0xDC00 + 0x10000;
-					let hexadecimal = codePoint.toString(16);
-					if (!lowercaseHex) {
-						hexadecimal = hexadecimal.toUpperCase();
-					}
-					result += '\\u{' + hexadecimal + '}';
-					++index;
-					continue;
-				}
+	const regex = options.escapeEverything ? escapeEverythingRegex : escapeNonAsciiRegex;
+	result = argument.replace(regex, (char, pair, lone, quoteChar, index, string) => {
+		if (pair) {
+			if (options.minimal) return pair;
+			const first = pair.charCodeAt(0);
+			const second = pair.charCodeAt(1);
+			if (options.es6) {
+				// https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+				const codePoint = (first - 0xD800) * 0x400 + second - 0xDC00 + 0x10000;
+				const hex = hexadecimal(codePoint, lowercaseHex);
+				return '\\u{' + hex + '}';
 			}
+			return fourHexEscape(hexadecimal(first, lowercaseHex)) + fourHexEscape(hexadecimal(second, lowercaseHex));
 		}
-		if (!options.escapeEverything) {
-			if (regexWhitelist.test(character)) {
-				// It’s a printable ASCII character that is not `"`, `'` or `\`,
-				// so don’t escape it.
-				result += character;
-				continue;
-			}
-			if (character == '"') {
-				result += quote == character ? '\\"' : character;
-				continue;
-			}
-			if (character == '`') {
-				result += quote == character ? '\\`' : character;
-				continue;
-			}
-			if (character == '\'') {
-				result += quote == character ? '\\\'' : character;
-				continue;
-			}
+
+		if (lone) {
+			return fourHexEscape(hexadecimal(lone.charCodeAt(0), lowercaseHex));
 		}
+
 		if (
-			character == '\0' &&
+			char == '\0' &&
 			!json &&
 			!regexDigit.test(string.charAt(index + 1))
 		) {
-			result += '\\0';
-			continue;
+			return '\\0';
 		}
-		if (regexSingleEscape.test(character)) {
+
+		if (quoteChar) {
+			if (quoteChar == quote || options.escapeEverything) {
+				return '\\' + quoteChar;
+			}
+			return quoteChar;
+		}
+
+		if (regexSingleEscape.test(char)) {
 			// no need for a `hasOwnProperty` check here
-			result += singleEscapes[character];
-			continue;
+			return singleEscapes[char];
 		}
-		const charCode = character.charCodeAt(0);
-		if (options.minimal && charCode != 0x2028 && charCode != 0x2029) {
-			result += character;
-			continue;
+
+		if (options.minimal && char != '\u2028' && char != '\u2029') {
+			return char;
 		}
-		let hexadecimal = charCode.toString(16);
-		if (!lowercaseHex) {
-			hexadecimal = hexadecimal.toUpperCase();
+
+		const hex = hexadecimal(char.charCodeAt(0), lowercaseHex);
+		if (json || hex.length > 2) {
+			return fourHexEscape(hex);
 		}
-		const longhand = hexadecimal.length > 2 || json;
-		const escaped = '\\' + (longhand ? 'u' : 'x') +
-			('0000' + hexadecimal).slice(longhand ? -4 : -2);
-		result += escaped;
-		continue;
-	}
-	if (options.wrap) {
-		result = quote + result + quote;
-	}
+
+		return '\\x' + ('00' + hex).slice(-2);
+	});
+
 	if (quote == '`') {
-		result = result.replace(/\$\{/g, '\\\$\{');
+		result = result.replace(/\$\{/g, '\\${');
 	}
 	if (options.isScriptContext) {
 		// https://mathiasbynens.be/notes/etago
-		return result
+		result = result
 			.replace(/<\/(script|style)/gi, '<\\/$1')
 			.replace(/<!--/g, json ? '\\u003C!--' : '\\x3C!--');
+	}
+	if (options.wrap) {
+		result = quote + result + quote;
 	}
 	return result;
 };

--- a/src/jsesc.js
+++ b/src/jsesc.js
@@ -36,7 +36,7 @@ const hexadecimal = (code, lowercase) => {
 	let hexadecimal = code.toString(16);
 	if (lowercase) return hexadecimal;
 	return hexadecimal.toUpperCase();
-}
+};
 
 const toString = object.toString;
 const isArray = Array.isArray;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -617,7 +617,7 @@ describe('advanced tests', function() {
 			jsesc(testArray, {
 				'json': false
 			}),
-			'[undefined,Infinity,Infinity,-Infinity,-Infinity,0,0,0,0,0,0,function anonymous() {\n\n},\'str\',function zomg() { return \'desu\'; },null,true,true,false,false,{\'foo\':42,\'hah\':[1,2,3,{\'foo\':42}]}]',
+			'[undefined,Infinity,Infinity,-Infinity,-Infinity,0,0,0,0,0,0,function anonymous(\n) {\n\n},\'str\',function zomg() { return \'desu\'; },null,true,true,false,false,{\'foo\':42,\'hah\':[1,2,3,{\'foo\':42}]}]',
 			'Escaping a non-flat array with all kinds of values'
 		);
 		assert.equal(

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -89,10 +89,10 @@ describe('common usage', function() {
 			'escapeEverything'
 		);
 		assert.equal(
-			jsesc('\0foo\u2029bar\nbaz\xA9qux\uD834\uDF06flops', {
+			jsesc('\0foo\u2029bar\nbaz\xA9qux\uD834\uDF06flops\uD834_\uDF06_\uDF06\uD834', {
 				'minimal': true
 			}),
-			'\\0foo\\u2029bar\\nbaz\xA9qux\uD834\uDF06flops',
+			'\\0foo\\u2029bar\\nbaz\xA9qux\uD834\uDF06flops\\uD834_\\uDF06_\\uDF06\\uD834',
 			'minimal'
 		);
 		assert.equal(
@@ -617,7 +617,7 @@ describe('advanced tests', function() {
 			jsesc(testArray, {
 				'json': false
 			}),
-			'[undefined,Infinity,Infinity,-Infinity,-Infinity,0,0,0,0,0,0,function anonymous(\n) {\n\n},\'str\',function zomg() { return \'desu\'; },null,true,true,false,false,{\'foo\':42,\'hah\':[1,2,3,{\'foo\':42}]}]',
+			'[undefined,Infinity,Infinity,-Infinity,-Infinity,0,0,0,0,0,0,function anonymous() {\n\n},\'str\',function zomg() { return \'desu\'; },null,true,true,false,false,{\'foo\':42,\'hah\':[1,2,3,{\'foo\':42}]}]',
 			'Escaping a non-flat array with all kinds of values'
 		);
 		assert.equal(
@@ -635,5 +635,5 @@ describe('advanced tests', function() {
 			'[\n\tnull,\n\tnull,\n\tnull,\n\tnull,\n\tnull,\n\t0,\n\t0,\n\t0,\n\t0,\n\t0,\n\t0,\n\tnull,\n\t"str",\n\tnull,\n\tnull,\n\ttrue,\n\ttrue,\n\tfalse,\n\tfalse,\n\t{\n\t\t"foo": 42,\n\t\t"hah": [\n\t\t\t1,\n\t\t\t2,\n\t\t\t3,\n\t\t\t{\n\t\t\t\t"foo": 42\n\t\t\t}\n\t\t]\n\t}\n]',
 			'Escaping a non-flat array with all kinds of values, with `json: true, compact: false`'
 		);
-	}).timeout(25000);
+	});
 });


### PR DESCRIPTION
This allows the engine to skip all blocks of valid ASCII chars, considerably speeding it up. The tests, which include an escape for every 16th code point between `0` and `0x10FFFF`, goes from ~24s to ~700ms (a 34x speedup).

This subsumes https://github.com/mathiasbynens/jsesc/pull/60.