### PR TITLE
feat: check for Buffer existence

### DIFF
--- a/jsesc.js
+++ b/jsesc.js
@@ -41,7 +41,7 @@ const hexadecimal = (code, lowercase) => {
 const toString = object.toString;
 const isArray = Array.isArray;
 const isBuffer = (value) => {
-	return typeof Buffer !== 'undefined' && Buffer.isBuffer(value);
+	return typeof Buffer === 'function' && Buffer.isBuffer(value);
 };
 const isObject = (value) => {
 	// This is a very simple check, but it’s good enough for what we need.

--- a/jsesc.js
+++ b/jsesc.js
@@ -40,7 +40,9 @@ const hexadecimal = (code, lowercase) => {
 
 const toString = object.toString;
 const isArray = Array.isArray;
-const isBuffer = Buffer.isBuffer;
+const isBuffer = (value) => {
+	return typeof Buffer !== 'undefined' && Buffer.isBuffer(value);
+};
 const isObject = (value) => {
 	// This is a very simple check, but it’s good enough for what we need.
 	return toString.call(value) == '[object Object]';

--- a/src/jsesc.js
+++ b/src/jsesc.js
@@ -41,7 +41,7 @@ const hexadecimal = (code, lowercase) => {
 const toString = object.toString;
 const isArray = Array.isArray;
 const isBuffer = (value) => {
-	return typeof Buffer !== 'undefined' && Buffer.isBuffer(value);
+	return typeof Buffer === 'function' && Buffer.isBuffer(value);
 };
 const isObject = (value) => {
 	// This is a very simple check, but it’s good enough for what we need.

--- a/src/jsesc.js
+++ b/src/jsesc.js
@@ -40,7 +40,9 @@ const hexadecimal = (code, lowercase) => {
 
 const toString = object.toString;
 const isArray = Array.isArray;
-const isBuffer = Buffer.isBuffer;
+const isBuffer = (value) => {
+	return typeof Buffer !== 'undefined' && Buffer.isBuffer(value);
+};
 const isObject = (value) => {
 	// This is a very simple check, but it’s good enough for what we need.
 	return toString.call(value) == '[object Object]';


### PR DESCRIPTION
Check for existence of `Buffer` so it doesn't throw in environments that don't implement it.

Closes https://github.com/mathiasbynens/jsesc/issues/63

I didn't add any test since testing this is pretty awkward but could add something like this if needed:

```js
it('does not throw when Buffer is not defined', function() {
  assert.doesNotThrow(function() {
    const _Buffer = global.Buffer;
    global.Buffer = undefined;
    delete require.cache[require.resolve('../jsesc.js')];
    require('../jsesc.js');
    global.Buffer = _Buffer;
  });
});
```