### PR TITLE
feat: add support for typed arrays

### DIFF
--- a/jsesc.js
+++ b/jsesc.js
@@ -70,6 +70,20 @@ const isSet = (value) => {
 
 /*--------------------------------------------------------------------------*/
 
+const typedArrayClassNames = [
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'Uint16Array',
+  'Uint32Array',
+  'BigUint64Array',
+  'Int8Array',
+  'Int16Array',
+  'Int32Array',
+  'BigInt64Array',
+  'Float32Array',
+  'Float64Array'
+]
+
 // https://mathiasbynens.be/notes/javascript-escapes#single
 const singleEscapes = {
 	'\\': '\\\\',
@@ -172,6 +186,16 @@ const jsesc = (argument, options) => {
 			}
 			return 'Buffer.from(' + jsesc(Array.from(argument), options) + ')';
 		}
+    const typedArrayClassName = typedArrayClassNames.find(
+      typedArray => toString.call(argument) == '[object ' + typedArray + ']'
+    );
+    if (typedArrayClassName) {
+      if (argument.length == 0) {
+        return 'new ' + typedArrayClassName + '()';
+      }
+      return 'new ' + typedArrayClassName + '(' +
+        jsesc(Array.from(argument), options) + ')';
+    }
 		if (isArray(argument)) {
 			result = [];
 			options.wrap = true;
@@ -332,6 +356,6 @@ const jsesc = (argument, options) => {
 	return result;
 };
 
-jsesc.version = '3.0.2';
+jsesc.version = '3.1.0';
 
 module.exports = jsesc;

--- a/src/jsesc.js
+++ b/src/jsesc.js
@@ -70,6 +70,20 @@ const isSet = (value) => {
 
 /*--------------------------------------------------------------------------*/
 
+const typedArrayClassNames = [
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'Uint16Array',
+  'Uint32Array',
+  'BigUint64Array',
+  'Int8Array',
+  'Int16Array',
+  'Int32Array',
+  'BigInt64Array',
+  'Float32Array',
+  'Float64Array'
+]
+
 // https://mathiasbynens.be/notes/javascript-escapes#single
 const singleEscapes = {
 	'\\': '\\\\',
@@ -172,6 +186,16 @@ const jsesc = (argument, options) => {
 			}
 			return 'Buffer.from(' + jsesc(Array.from(argument), options) + ')';
 		}
+    const typedArrayClassName = typedArrayClassNames.find(
+      typedArray => toString.call(argument) == '[object ' + typedArray + ']'
+    );
+    if (typedArrayClassName) {
+      if (argument.length == 0) {
+        return 'new ' + typedArrayClassName + '()';
+      }
+      return 'new ' + typedArrayClassName + '(' +
+        jsesc(Array.from(argument), options) + ')';
+    }
 		if (isArray(argument)) {
 			result = [];
 			options.wrap = true;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -597,6 +597,61 @@ describe('common usage', function() {
 			'\\u2192\\xE9\\u{1F4A9}',
 			'Alphabetical hexadecimal digits are uppercase when `lowercaseHex: false` and `es6: true`'
 		);
+    assert.equal(
+      jsesc([new Uint8Array(), new Uint8Array([1, 2, 3])]),
+      '[new Uint8Array(),new Uint8Array([1,2,3])]',
+      'Uint8Array'
+    );
+    assert.equal(
+      jsesc([new Uint8ClampedArray(), new Uint8ClampedArray([1, 2, 3])]),
+      '[new Uint8ClampedArray(),new Uint8ClampedArray([1,2,3])]',
+      'Uint8ClampedArray'
+    );
+    assert.equal(
+      jsesc([new Uint16Array(), new Uint16Array([1, 2, 3])]),
+      '[new Uint16Array(),new Uint16Array([1,2,3])]',
+      'Uint16Array'
+    );
+    assert.equal(
+      jsesc([new Uint32Array(), new Uint32Array([1, 2, 3])]),
+      '[new Uint32Array(),new Uint32Array([1,2,3])]',
+      'Uint32Array'
+    );
+    assert.equal(
+      jsesc([new BigUint64Array(), new BigUint64Array([1n, 2n, 3n])]),
+      '[new BigUint64Array(),new BigUint64Array([1n,2n,3n])]',
+      'BigUint64Array'
+    );
+    assert.equal(
+      jsesc([new Int8Array(), new Int8Array([-1, 2, 3])]),
+      '[new Int8Array(),new Int8Array([-1,2,3])]',
+      'Int8Array'
+    );
+    assert.equal(
+      jsesc([new Int16Array(), new Int16Array([-1, 2, 3])]),
+      '[new Int16Array(),new Int16Array([-1,2,3])]',
+      'Int16Array'
+    );
+    assert.equal(
+      jsesc([new Int32Array(), new Int32Array([-1, 2, 3])]),
+      '[new Int32Array(),new Int32Array([-1,2,3])]',
+      'Int32Array'
+    );
+    assert.equal(
+      jsesc([new BigInt64Array(), new BigInt64Array([-1n, 2n, 3n])]),
+      '[new BigInt64Array(),new BigInt64Array([-1n,2n,3n])]',
+      'BigInt64Array'
+    );
+    assert.equal(
+      jsesc([new Float32Array(), new Float32Array([1.5, 2.5, 4.5])]),
+      '[new Float32Array(),new Float32Array([1.5,2.5,4.5])]',
+      'Float32Array'
+    );
+    assert.equal(
+      jsesc([new Float64Array(), new Float64Array([1.5, 2.5, 4.5])]),
+      '[new Float64Array(),new Float64Array([1.5,2.5,4.5])]',
+      'Float64Array'
+    );
 	});
 });
 


### PR DESCRIPTION
Like the last PR, this shouldn't bump the minimum supported node version because we never reference the typed array constructors.